### PR TITLE
Added logic to fetch data properly, and calculate trend and probabili…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import NotFound from "./pages/NotFound";
 import SidebarNavigation from "./components/SidebarNavigation";
 import { useState, useEffect } from "react";
 import AIAnalysisPage from './pages/ai-analysis';
+import { MarketDataProvider } from "./context/MarketDataContext";
 
 const queryClient = new QueryClient();
 
@@ -40,7 +41,11 @@ const AnimatedRoutes = () => {
       <main className={showSidebar ? "ml-[280px] transition-all duration-300" : ""}>
         <AnimatePresence mode="wait">
           <Routes location={location} key={location.pathname}>
-            <Route path="/" element={<Index />} />
+            <Route path="/" element={
+              <MarketDataProvider>
+                <Index />
+              </MarketDataProvider>
+            } />
             <Route path="/technology" element={<TechnologyPage />} />
             <Route path="/about" element={<AboutPage />} />
             <Route path="/contact" element={<ContactPage />} />

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -15,7 +15,7 @@ import {
   AlertCircle,
   CheckCircle
 } from "lucide-react";
-import { useMultipleCryptoPrices } from "@/hooks/useCryptoPrice";
+import { useMarketData } from "@/context/MarketDataContext";
 import { cn, formatCryptoPrice, formatPercent } from "@/lib/utils";
 
 // Animated background particles
@@ -157,7 +157,7 @@ const TiltContainer = ({ children }: { children: React.ReactNode }) => {
 
 const HeroSection = () => {
   const [isVisible, setIsVisible] = useState(false);
-  const { data: cryptoData, isLoading } = useMultipleCryptoPrices(['BTC', 'ETH']);
+  const { cryptoPrices, isLoading } = useMarketData();
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -168,7 +168,7 @@ const HeroSection = () => {
   }, []);
 
   // Get Bitcoin data with fallback values
-  const btcData = cryptoData?.BTC || {
+  const btcData = cryptoPrices['BTC'] || {
     price: 48632.75,
     percentChange: 2.34,
     lastUpdated: new Date().toISOString(),
@@ -176,7 +176,7 @@ const HeroSection = () => {
   };
 
   // Get Ethereum data with fallback values
-  const ethData = cryptoData?.ETH || {
+  const ethData = cryptoPrices['ETH'] || {
     price: 3295.84,
     percentChange: 1.87,
     lastUpdated: new Date().toISOString(),

--- a/src/components/SidebarNavigation.tsx
+++ b/src/components/SidebarNavigation.tsx
@@ -77,7 +77,7 @@ const SidebarNavigation = ({ className }: SidebarNavProps) => {
   const formatPrice = (price: number, symbol: string) => {
     return new Intl.NumberFormat('en-US', {
       minimumFractionDigits: 2,
-      maximumFractionDigits: symbol === 'BTC' ? 2 : 2
+      maximumFractionDigits: 2
     }).format(price);
   };
 

--- a/src/context/MarketDataContext.tsx
+++ b/src/context/MarketDataContext.tsx
@@ -1,0 +1,207 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { fetchCryptoPrice, fetchForexPrices, CryptoPrice, ForexPrice, TimeframeData, InstrumentTimeframeData } from '../lib/api';
+
+// Extended interfaces for timeframe analysis
+interface TimeframeAnalysis {
+  timeframe: string;
+  trend: 'up' | 'down' | 'neutral';
+  strength: number;
+  support: number;
+  resistance: number;
+  lastUpdated: string;
+}
+
+interface MarketDataContextType {
+  cryptoPrices: Record<string, CryptoPrice>;
+  forexPrices: Record<string, ForexPrice>;
+  isLoading: boolean;
+  error: string | null;
+  refreshData: () => Promise<void>;
+  getTimeframeAnalysis: (symbol: string, timeframe: string) => TimeframeAnalysis | null;
+  getTimeframeData: (symbol: string, timeframe: string) => TimeframeData[] | null;
+}
+
+const MarketDataContext = createContext<MarketDataContextType | undefined>(undefined);
+
+// Utility functions for timeframe analysis
+const calculateMA50 = (data: TimeframeData[]): number => {
+  if (data.length < 50) return 0;
+  const closes = data.slice(0, 50).map(d => d.close);
+  return closes.reduce((a, b) => a + b, 0) / closes.length;
+};
+
+const calculateMA200 = (data: TimeframeData[]): number => {
+  if (data.length < 200) return 0;
+  const closes = data.map(d => d.close);
+  return closes.reduce((a, b) => a + b, 0) / closes.length;
+};
+
+const calculateTrend = (data: TimeframeData[]): 'up' | 'down' | 'neutral' => {
+  if (data.length < 200) return 'neutral';
+  
+  const currentPrice = data[0].close;
+  const ma50 = calculateMA50(data);
+  const ma200 = calculateMA200(data);
+  
+  if (currentPrice > ma50 && currentPrice > ma200) return 'up';
+  if (currentPrice < ma50 && currentPrice < ma200) return 'down';
+  return 'neutral';
+};
+
+const calculateStrength = (data: TimeframeData[]): number => {
+  if (data.length < 2) return 0;
+  
+  const recentData = data.slice(0, 20); // Look at last 20 candles
+  const closes = recentData.map(d => d.close);
+  const returns = closes.slice(1).map((price, i) => (price - closes[i]) / closes[i]);
+  const avgReturn = returns.reduce((a, b) => a + b, 0) / returns.length;
+  
+  return Math.abs(avgReturn) * 100; // Convert to percentage
+};
+
+const calculateSupportResistance = (data: TimeframeData[]): { support: number; resistance: number } => {
+  if (data.length < 20) return { support: 0, resistance: 0 };
+  
+  const recentData = data.slice(0, 20);
+  const lows = recentData.map(d => d.low);
+  const highs = recentData.map(d => d.high);
+  
+  return {
+    support: Math.min(...lows),
+    resistance: Math.max(...highs)
+  };
+};
+
+export const MarketDataProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [cryptoPrices, setCryptoPrices] = useState<Record<string, CryptoPrice>>({});
+  const [forexPrices, setForexPrices] = useState<Record<string, ForexPrice>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Function to fetch current prices only
+  const fetchCurrentPrices = async () => {
+    try {
+      setError(null);
+
+      // Fetch all required crypto prices
+      const cryptoPromises = ['BTC', 'ETH', 'XRP', 'SOL'].map(symbol =>
+        fetchCryptoPrice(symbol, 'USD', false) // Pass false to skip historical data
+      );
+
+      const cryptoResults = await Promise.all(cryptoPromises);
+      const newCryptoPrices = cryptoResults.reduce((acc, result) => ({
+        ...acc,
+        [result.symbol]: result
+      }), {} as Record<string, CryptoPrice>);
+
+      // Fetch forex prices
+      const forexData = await fetchForexPrices(false); // Pass false to skip historical data
+
+      setCryptoPrices(newCryptoPrices);
+      setForexPrices(forexData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  // Function to fetch historical data
+  const fetchHistoricalData = async () => {
+    try {
+      setError(null);
+
+      // Fetch all required crypto prices with historical data
+      const cryptoPromises = ['BTC', 'ETH', 'XRP', 'SOL'].map(symbol =>
+        fetchCryptoPrice(symbol, 'USD', true) // Pass true to include historical data
+      );
+
+      const cryptoResults = await Promise.all(cryptoPromises);
+      const newCryptoPrices = cryptoResults.reduce((acc, result) => ({
+        ...acc,
+        [result.symbol]: result
+      }), {} as Record<string, CryptoPrice>);
+
+      // Fetch forex prices with historical data
+      const forexData = await fetchForexPrices(true); // Pass true to include historical data
+
+      setCryptoPrices(newCryptoPrices);
+      setForexPrices(forexData);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred');
+    }
+  };
+
+  // Utility function to get timeframe analysis
+  const getTimeframeAnalysis = (symbol: string, timeframe: string): TimeframeAnalysis | null => {
+    const data = getTimeframeData(symbol, timeframe);
+    if (!data || data.length === 0) return null;
+
+    const trend = calculateTrend(data);
+    const strength = calculateStrength(data);
+    const { support, resistance } = calculateSupportResistance(data);
+
+    return {
+      timeframe,
+      trend,
+      strength,
+      support,
+      resistance,
+      lastUpdated: new Date().toISOString()
+    };
+  };
+
+  // Utility function to get timeframe data
+  const getTimeframeData = (symbol: string, timeframe: string): TimeframeData[] | null => {
+    // Check if symbol is a crypto or forex pair
+    const isCrypto = symbol.includes('/USD');
+    const data = isCrypto ? cryptoPrices[symbol] : forexPrices[symbol];
+    
+    if (!data || !data.timeframeData) return null;
+    return data.timeframeData[timeframe] || null;
+  };
+
+  // Initial data fetch
+  useEffect(() => {
+    const initialFetch = async () => {
+      setIsLoading(true);
+      await fetchHistoricalData(); // Fetch everything on initial load
+      setIsLoading(false);
+    };
+    initialFetch();
+  }, []);
+
+  // Set up intervals for regular updates
+  useEffect(() => {
+    // Update current prices every 5 minutes
+    const priceInterval = setInterval(fetchCurrentPrices, 300000);
+
+    // Update historical data every 15 minutes to avoid rate limits
+    const historicalInterval = setInterval(fetchHistoricalData, 900000);
+
+    return () => {
+      clearInterval(priceInterval);
+      clearInterval(historicalInterval);
+    };
+  }, []);
+
+  return (
+    <MarketDataContext.Provider value={{
+      cryptoPrices,
+      forexPrices,
+      isLoading,
+      error,
+      refreshData: fetchHistoricalData,
+      getTimeframeAnalysis,
+      getTimeframeData
+    }}>
+      {children}
+    </MarketDataContext.Provider>
+  );
+};
+
+export const useMarketData = () => {
+  const context = useContext(MarketDataContext);
+  if (context === undefined) {
+    throw new Error('useMarketData must be used within a MarketDataProvider');
+  }
+  return context;
+}; 

--- a/src/hooks/useCryptoPrice.ts
+++ b/src/hooks/useCryptoPrice.ts
@@ -32,8 +32,8 @@ export const useCryptoPrice = (symbol: string) => {
 
     fetchData();
 
-    // Set up polling for real-time updates (every 60 seconds)
-    const intervalId = setInterval(fetchData, 60000);
+    // Set up polling for real-time updates (every 5 minutes)
+    const intervalId = setInterval(fetchData, 300000);
 
     return () => {
       isMounted = false;
@@ -75,8 +75,8 @@ export const useMultipleCryptoPrices = (symbols: string[]) => {
 
     fetchData();
 
-    // Set up polling for real-time updates (every 60 seconds)
-    const intervalId = setInterval(fetchData, 60000);
+    // Set up polling for real-time updates (every 5 minutes)
+    const intervalId = setInterval(fetchData, 300000);
 
     return () => {
       isMounted = false;
@@ -118,8 +118,8 @@ export const useForexPrices = () => {
 
     fetchData();
 
-    // Set up polling for real-time updates (every 60 seconds)
-    const intervalId = setInterval(fetchData, 60000);
+    // Set up polling for real-time updates (every 5 minutes)
+    const intervalId = setInterval(fetchData, 300000);
 
     return () => {
       isMounted = false;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -58,14 +58,7 @@ export function formatPercent(value: number, options?: {
 
 // Format cryptocurrency values appropriately
 export function formatCryptoPrice(value: number, symbol: string) {
-  // Different precision for different coins
-  const precision = {
-    'BTC': 2,
-    'ETH': 2,
-    'XRP': 4,
-  }[symbol] || 2;
-
-  return formatNumber(value, { minimumFractionDigits: precision, maximumFractionDigits: precision });
+  return formatNumber(value, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
 }
 
 // Convert date to relative time (e.g., "2 hours ago")

--- a/src/pages/AIAnalysisPage.tsx
+++ b/src/pages/AIAnalysisPage.tsx
@@ -214,7 +214,7 @@ const AIAnalysisPage: React.FC = () => {
     };
 
     fetchAllData();
-    const interval = setInterval(fetchAllData, 60000); // Update every minute
+    const interval = setInterval(fetchAllData, 300000); // Update every 5 minutes
     return () => clearInterval(interval);
   }, [selectedTimeFrame]);
 


### PR DESCRIPTION
The push includes below changes
1) We can fetch data from TwelveData API endpoints, and have included 5 keys as of now in a retry logic to not exhaust them.
2) We are calculating timeframes wise moving average and then calculating signals on that basis
3) We are calculating success probability depending on the given percent weightage of each time frame.